### PR TITLE
fix: include test workflow in generated starter apps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,6 @@
 *.md diff=markdown
 *.php diff=php
 
-/.github export-ignore
+/.github/workflows/fresh-install.yml export-ignore
 CHANGELOG.md export-ignore
 .styleci.yml export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Copy environment file
+        run: cp .env.example .env
+
+      - name: Generate app key
+        run: php artisan key:generate
+
+      - name: Execute tests
+        run: php artisan test


### PR DESCRIPTION
## Summary
- add the Laravel installer-compatible `tests.yml` workflow to the starter archive
- keep the repository-only `fresh-install.yml` excluded from generated projects

## Validation
- generated a project from this branch using `laravel new --using=nativephp/mobile-starter:dev-codex/fix-starter-tests-workflow --pest --no-interaction`
- verified Laravel rewrites the workflow to `./vendor/bin/pest` with no missing-file warnings
- ran `php artisan test` successfully (8 tests, 81 assertions)